### PR TITLE
Ajout de scripts pour maintenir la base

### DIFF
--- a/class/AccountsApi.class.php
+++ b/class/AccountsApi.class.php
@@ -74,6 +74,18 @@ class AccountsApi {
 	private function swapUid($in){
 		return $in[6].$in[7].$in[4].$in[5].$in[2].$in[3].$in[0].$in[1];
 	}
+    
+    public function getLoginsWithoutActiveCard() {
+        return $this->apiCall("getLoginsWithoutActiveCard");
+    }
+    
+    public function getModifiedCards($date) {
+        $params = array(
+            "startDate" => $date
+        );
+        
+        return $this->apiCall("getModifiedCards", $params);
+    }
 }
 
 ?>

--- a/class/GingerMaintenance.class.php
+++ b/class/GingerMaintenance.class.php
@@ -1,0 +1,80 @@
+<?php
+
+require_once '../lib/Koala/Koala.class.php';
+use \Koala\ApiException;
+
+require_once 'AccountsApi.class.php';
+
+class GingerMaintenance {
+    protected $accounts;
+    
+    public function __construct($accounts_url) {
+        // Initialisation de Accounts
+        $this->accounts = new AccountsApi(Config::$ACCOUNTS_URL);
+    }
+    
+    public function cleanupLoginsWithoutActiveCards() {
+        $log = "Nettoyage des badges\n";
+
+        // Récupérer la liste des badges à désactiver
+        $logins = $this->accounts->getLoginsWithoutActiveCard();
+    
+        // On fait une transaction pour améliorer les performances
+        $con = Propel::getConnection(PersonnePeer::DATABASE_NAME);
+        $con->beginTransaction();
+    
+        foreach($logins as $login){
+            if(!empty($login)) {
+                $personne = PersonneQuery::create('p')
+                    ->where("p.login = ?", $login)
+                    ->findOne();
+                
+                if(!empty($personne)){
+                    $personne->setBadgeUid(null);
+                    $personne->save();                    
+                    $log .= "$login:ok null\n";
+                } else {
+                    $log .= "$login:absent\n";
+                }
+            }
+        }
+    
+        // Fin de la transaction
+        $con->commit();
+        
+        return $log;
+    }
+    
+    public function updateModifiedCards($date = null) {
+        if($date == null) {
+            $date = date("Y-m-d");
+        }
+        
+        $log = "Mise à jour des badges modifiés après le $date\n";
+        
+        // Récupérer la liste des badges à désactiver
+        $cards = $this->accounts->getModifiedCards($date);
+        
+        foreach($cards as $accountsData){
+            if(!empty($accountsData)) {
+                
+                // Il existe, on recherche son login dans ginger (ou on lui fait une nouvelle ligne)
+                $personne = PersonneQuery::create('p')
+                    ->where("p.login = ?", $accountsData->username)
+                    ->findOne();
+			
+                if(!empty($personne)) {
+                    // On met à jour toutes les données (notamment le badge) avec ce qu'on a déjà récupéré
+                    $personne->updateFromAccounts($accountsData);
+                    
+                    $log .= $accountsData->username.":updated\n";
+                } else {
+                    $log .= $accountsData->username.":absent\n";
+                }
+            }
+        }
+        
+        return $log;
+    }
+
+}

--- a/cron/cleanupInactive.php
+++ b/cron/cleanupInactive.php
@@ -1,0 +1,8 @@
+<?php
+require 'init.php';
+
+$ginger = new GingerMaintenance(Config::$ACCOUNTS_URL);
+
+echo $ginger->cleanupLoginsWithoutActiveCards();
+
+

--- a/cron/init.php
+++ b/cron/init.php
@@ -1,0 +1,15 @@
+<?php
+
+// Include all dependencies
+require_once '../vendor/autoload.php';
+
+// Include model
+Propel::init("../build/conf/ginger-conf.php");
+set_include_path("../build/classes" . PATH_SEPARATOR . get_include_path());
+
+// Include config
+require_once '../config.php';
+
+require_once '../lib/Koala/Koala.class.php';
+require_once '../class/GingerMaintenance.class.php';
+

--- a/cron/updateBadges.php
+++ b/cron/updateBadges.php
@@ -1,0 +1,14 @@
+<?php
+require 'init.php';
+
+$ginger = new GingerMaintenance(Config::$ACCOUNTS_URL);
+
+if(empty($argv[1])) {
+    $date = date("Y-m-d", time() - 24*3600);
+} else {
+    $date = $argv[1];
+}
+
+echo $ginger->updateModifiedCards($date);
+
+


### PR DESCRIPTION
- cleanupInactive.php : supprime tous les UID de badges déclarés comme inactifs par la DSI
- updateBadges.php : met à jour les badges ayant changé depuis la date passé en argument ou hier par défaut
