### PR TITLE
Majuscules forcées pour les UID

### DIFF
--- a/class/AccountsApi.class.php
+++ b/class/AccountsApi.class.php
@@ -72,7 +72,7 @@ class AccountsApi {
 	}
 	
 	private function swapUid($in){
-		return $in[6].$in[7].$in[4].$in[5].$in[2].$in[3].$in[0].$in[1];
+		return strtoupper($in[6].$in[7].$in[4].$in[5].$in[2].$in[3].$in[0].$in[1]);
 	}
 }
 


### PR DESCRIPTION
La nouvelle version de Accounts ne retourne pas les UID en majuscules, on le force pour être parfaitement rétro-compatibles
